### PR TITLE
opened up the "visible" property in .spec | Fixes servoy/svywebcam#6

### DIFF
--- a/svywebcam/webcam/webcam.spec
+++ b/svywebcam/webcam/webcam.spec
@@ -48,7 +48,8 @@
 			{
 				"scope": "private"
 			}
-		}
+		},
+		"visible": "visible"
 	},
 
 	"api": 


### PR DESCRIPTION
Hi, 

after i opened the issue #6 i tried to make it myself for better understanding in servoy-components / angular stuff.

I just edited the .spec file and added the "visible" model to the structure.
Tested it with Servoy 2024.12.0. It works there how i need it.

As far as i can see, there is the _doc.js missing. Maybe i can try to do it aswell in the future.

Greetings
-Vik